### PR TITLE
[DOR-192][AO] send explicit audit events

### DIFF
--- a/app/uk/gov/hmrc/traderservices/controllers/ControllerHelper.scala
+++ b/app/uk/gov/hmrc/traderservices/controllers/ControllerHelper.scala
@@ -33,7 +33,7 @@ import play.api.libs.json.Json
 
 trait ControllerHelper {
 
-  type HandleError = (String, String) => Result
+  type HandleError = (String, String) => Future[Result]
 
   protected def withPayload[T](
     f: T => Future[Result]
@@ -54,14 +54,14 @@ trait ControllerHelper {
             f(payload)
 
           case Invalid(errs) =>
-            Future successful handleError(
+            handleError(
               "ERROR_VALIDATION",
               s"Invalid payload: Validation failed due to ${errs.mkString(", and ")}."
             )
         }
 
       case Success(JsError(errs)) =>
-        Future successful handleError(
+        handleError(
           "ERROR_JSON",
           s"Invalid payload: Parsing failed due to ${errs
             .map {
@@ -72,7 +72,7 @@ trait ControllerHelper {
         )
 
       case Failure(e) =>
-        Future successful handleError("ERROR_UNKNOWN", s"Could not parse payload due to ${e.getMessage}.")
+        handleError("ERROR_UNKNOWN", s"Could not parse payload due to ${e.getMessage}.")
     }
 
 }

--- a/app/uk/gov/hmrc/traderservices/controllers/TraderServicesRouteOneController.scala
+++ b/app/uk/gov/hmrc/traderservices/controllers/TraderServicesRouteOneController.scala
@@ -29,11 +29,9 @@ import scala.concurrent.ExecutionContext
 import uk.gov.hmrc.traderservices.connectors.PegaCreateCaseRequest
 import java.{util => ju}
 import views.html.defaultpages.error
-import uk.gov.hmrc.traderservices.models.TypeOfAmendment.UploadDocuments
-import uk.gov.hmrc.traderservices.models.TypeOfAmendment.WriteResponse
-import uk.gov.hmrc.traderservices.models.TypeOfAmendment.WriteResponseAndUploadDocuments
 import scala.concurrent.Future
 import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.traderservices.services.AuditService
 
 @Singleton
 class TraderServicesRouteOneController @Inject() (
@@ -42,6 +40,7 @@ class TraderServicesRouteOneController @Inject() (
   val updateCaseConnector: PegaUpdateCaseConnector,
   val env: Environment,
   val appConfig: AppConfig,
+  val auditService: AuditService,
   cc: ControllerComponents
 )(implicit val configuration: Configuration, ec: ExecutionContext)
     extends BackendController(cc) with AuthActions with ControllerHelper {
@@ -49,11 +48,11 @@ class TraderServicesRouteOneController @Inject() (
   // POST /create-case
   def createCase: Action[String] =
     Action.async(parse.tolerantText) { implicit request =>
-      withAuthorised {
-        val correlationId = request.headers
-          .get("x-correlation-id")
-          .getOrElse(ju.UUID.randomUUID().toString())
+      val correlationId = request.headers
+        .get("x-correlation-id")
+        .getOrElse(ju.UUID.randomUUID().toString())
 
+      withAuthorised {
         withPayload[TraderServicesCreateCaseRequest] { createCaseRequest =>
           val pegaCreateCaseRequest = PegaCreateCaseRequest(
             AcknowledgementReference = correlationId.replace("-", ""),
@@ -62,33 +61,49 @@ class TraderServicesRouteOneController @Inject() (
             Content = PegaCreateCaseRequest.Content.from(createCaseRequest)
           )
 
-          createCaseInPega(pegaCreateCaseRequest, correlationId)
+          createCaseInPega(
+            pegaCreateCaseRequest,
+            correlationId,
+            auditService.auditCreateCaseEvent(createCaseRequest)
+          )
 
         } {
           // when incoming request's payload validation fails
           case (errorCode, errorMessage) =>
-            BadRequest(
-              Json.toJson(
-                TraderServicesCaseResponse(
-                  correlationId = correlationId,
-                  error = Some(
-                    ApiError(errorCode, Some(errorMessage))
-                  )
-                )
+            val response = TraderServicesCaseResponse(
+              correlationId = correlationId,
+              error = Some(
+                ApiError(errorCode, Some(errorMessage))
               )
             )
+            auditService
+              .auditCreateCaseErrorEvent(response)
+              .map(_ => BadRequest(Json.toJson(response)))
         }
       }
+        .recoverWith {
+          // last resort fallback when request processing fails
+          case e =>
+            val response = TraderServicesCaseResponse(
+              correlationId = correlationId,
+              error = Some(
+                ApiError("500", Some(e.getMessage()))
+              )
+            )
+            auditService
+              .auditCreateCaseErrorEvent(response)
+              .map(_ => InternalServerError(Json.toJson(response)))
+        }
     }
 
   // POST /update-case
   def updateCase: Action[String] =
     Action.async(parse.tolerantText) { implicit request =>
-      withAuthorised {
-        val correlationId = request.headers
-          .get("x-correlation-id")
-          .getOrElse(ju.UUID.randomUUID().toString())
+      val correlationId = request.headers
+        .get("x-correlation-id")
+        .getOrElse(ju.UUID.randomUUID().toString())
 
+      withAuthorised {
         withPayload[TraderServicesUpdateCaseRequest] { updateCaseRequest =>
           val pegaCreateCaseRequest = PegaUpdateCaseRequest(
             AcknowledgementReference = correlationId.replace("-", ""),
@@ -97,90 +112,73 @@ class TraderServicesRouteOneController @Inject() (
             Content = PegaUpdateCaseRequest.Content.from(updateCaseRequest)
           )
 
-          updateCaseInPega(pegaCreateCaseRequest, correlationId)
+          updateCaseInPega(
+            pegaCreateCaseRequest,
+            correlationId,
+            auditService.auditUpdateCaseEvent(updateCaseRequest)
+          )
 
         } {
           // when incoming request's payload validation fails
           case (errorCode, errorMessage) =>
-            BadRequest(
-              Json.toJson(
-                TraderServicesCaseResponse(
-                  correlationId = correlationId,
-                  error = Some(
-                    ApiError(errorCode, Some(errorMessage))
-                  )
-                )
+            val response = TraderServicesCaseResponse(
+              correlationId = correlationId,
+              error = Some(
+                ApiError(errorCode, Some(errorMessage))
               )
             )
+            auditService
+              .auditUpdateCaseErrorEvent(response)
+              .map(_ => BadRequest(Json.toJson(response)))
         }
       }
+        .recoverWith {
+          // last resort fallback when request processing fails
+          case e =>
+            val response = TraderServicesCaseResponse(
+              correlationId = correlationId,
+              error = Some(
+                ApiError("500", Some(e.getMessage()))
+              )
+            )
+            auditService
+              .auditUpdateCaseErrorEvent(response)
+              .map(_ => InternalServerError(Json.toJson(response)))
+        }
     }
 
-  private def createCaseInPega(pegaCreateCaseRequest: PegaCreateCaseRequest, correlationId: String)(implicit
+  private def createCaseInPega(
+    pegaCreateCaseRequest: PegaCreateCaseRequest,
+    correlationId: String,
+    audit: TraderServicesCaseResponse => Future[Unit]
+  )(implicit
     hc: HeaderCarrier
   ): Future[Result] =
     createCaseConnector
-      .createCase(pegaCreateCaseRequest, correlationId) map {
-      case success: PegaCaseSuccess =>
-        Created(
-          Json.toJson(
-            TraderServicesCaseResponse(
-              correlationId = correlationId,
-              result = Some(success.CaseID)
-            )
+      .createCase(pegaCreateCaseRequest, correlationId)
+      .flatMap {
+        case success: PegaCaseSuccess =>
+          val response = TraderServicesCaseResponse(
+            correlationId = correlationId,
+            result = Some(success.CaseID)
           )
-        )
-      // when request to the upstream api returns an error
-      case error: PegaCaseError =>
-        if (error.isDuplicateCaseError)
-          Conflict(
-            Json.toJson(
-              TraderServicesCaseResponse(
-                correlationId = correlationId,
-                error = Some(
-                  ApiError(
-                    errorCode = "409",
-                    errorMessage = error.duplicateCaseID
-                  )
+          audit(response).map(_ => Created(Json.toJson(response)))
+        // when request to the upstream api returns an error
+        case error: PegaCaseError =>
+          if (error.isDuplicateCaseError) {
+            val response = TraderServicesCaseResponse(
+              correlationId = correlationId,
+              error = Some(
+                ApiError(
+                  errorCode = "409",
+                  errorMessage = error.duplicateCaseID
                 )
               )
             )
-          )
-        else
-          BadRequest(
-            Json.toJson(
-              TraderServicesCaseResponse(
-                correlationId = correlationId,
-                error = Some(
-                  ApiError(
-                    errorCode = error.errorCode.getOrElse("ERROR_UPSTREAM_UNDEFINED"),
-                    errorMessage = error.errorMessage
-                  )
-                )
-              )
-            )
-          )
-    }
-
-  private def updateCaseInPega(pegaCreateCaseRequest: PegaUpdateCaseRequest, correlationId: String)(implicit
-    hc: HeaderCarrier
-  ): Future[Result] =
-    updateCaseConnector
-      .updateCase(pegaCreateCaseRequest, correlationId) map {
-      case success: PegaCaseSuccess =>
-        Created(
-          Json.toJson(
-            TraderServicesCaseResponse(
-              correlationId = correlationId,
-              result = Some(success.CaseID)
-            )
-          )
-        )
-      // when request to the upstream api returns an error
-      case error: PegaCaseError =>
-        BadRequest(
-          Json.toJson(
-            TraderServicesCaseResponse(
+            audit(response)
+              .map(_ => Conflict(Json.toJson(response)))
+          } else {
+            val response = TraderServicesCaseResponse(
               correlationId = correlationId,
               error = Some(
                 ApiError(
@@ -189,7 +187,40 @@ class TraderServicesRouteOneController @Inject() (
                 )
               )
             )
+            audit(response)
+              .map(_ => BadRequest(Json.toJson(response)))
+          }
+      }
+
+  private def updateCaseInPega(
+    pegaCreateCaseRequest: PegaUpdateCaseRequest,
+    correlationId: String,
+    audit: TraderServicesCaseResponse => Future[Unit]
+  )(implicit
+    hc: HeaderCarrier
+  ): Future[Result] =
+    updateCaseConnector
+      .updateCase(pegaCreateCaseRequest, correlationId)
+      .flatMap {
+        case success: PegaCaseSuccess =>
+          val response = TraderServicesCaseResponse(
+            correlationId = correlationId,
+            result = Some(success.CaseID)
           )
-        )
-    }
+          audit(response)
+            .map(_ => Created(Json.toJson(response)))
+        // when request to the upstream api returns an error
+        case error: PegaCaseError =>
+          val response = TraderServicesCaseResponse(
+            correlationId = correlationId,
+            error = Some(
+              ApiError(
+                errorCode = error.errorCode.getOrElse("ERROR_UPSTREAM_UNDEFINED"),
+                errorMessage = error.errorMessage
+              )
+            )
+          )
+          audit(response)
+            .map(_ => BadRequest(Json.toJson(response)))
+      }
 }

--- a/app/uk/gov/hmrc/traderservices/models/TraderServicesCaseResponse.scala
+++ b/app/uk/gov/hmrc/traderservices/models/TraderServicesCaseResponse.scala
@@ -25,7 +25,10 @@ case class TraderServicesCaseResponse(
   error: Option[ApiError] = None,
   // Represents the result
   result: Option[String] = None
-)
+) {
+  def isSuccess: Boolean = error.isEmpty && result.isDefined
+  def isDuplicate: Boolean = error.exists(_.errorCode == "409")
+}
 
 object TraderServicesCaseResponse {
   implicit val formats: Format[TraderServicesCaseResponse] =

--- a/it/uk/gov/hmrc/traderservices/connectors/PegaCreateCaseConnectorISpec.scala
+++ b/it/uk/gov/hmrc/traderservices/connectors/PegaCreateCaseConnectorISpec.scala
@@ -14,6 +14,7 @@ class PegaCreateCaseConnectorISpec extends PegaCreateCaseConnectorISpecSetup {
     "createCase" should {
       "return case reference id if success" in {
         givenPegaCreateCaseRequestSucceeds()
+        givenAuditConnector()
 
         val request = testRequest
 
@@ -30,6 +31,7 @@ class PegaCreateCaseConnectorISpec extends PegaCreateCaseConnectorISpecSetup {
 
       "return error code and message if 500" in {
         givenPegaCreateCaseRequestFails(500, "500", "Foo Bar")
+        givenAuditConnector()
 
         val request = testRequest
 
@@ -48,6 +50,7 @@ class PegaCreateCaseConnectorISpec extends PegaCreateCaseConnectorISpecSetup {
 
       "return error code and message if 403" in {
         givenPegaCreateCaseRequestFails(403, "403", "Bar Foo")
+        givenAuditConnector()
 
         val request = testRequest
 

--- a/it/uk/gov/hmrc/traderservices/connectors/PegaUpdateCaseConnectorISpec.scala
+++ b/it/uk/gov/hmrc/traderservices/connectors/PegaUpdateCaseConnectorISpec.scala
@@ -1,7 +1,6 @@
 package uk.gov.hmrc.traderservices.connectors
 
 import play.api.Application
-import uk.gov.hmrc.traderservices.models._
 import uk.gov.hmrc.traderservices.stubs.UpdateCaseStubs
 import uk.gov.hmrc.traderservices.support.AppBaseISpec
 import uk.gov.hmrc.http._
@@ -14,6 +13,7 @@ class PegaUpdateCaseConnectorISpec extends PegaUpdateCaseConnectorISpecSetup {
     "updateCase" should {
       "return case reference id if success" in {
         givenPegaUpdateCaseRequestSucceeds()
+        givenAuditConnector()
 
         val request = testRequest
 
@@ -30,6 +30,7 @@ class PegaUpdateCaseConnectorISpec extends PegaUpdateCaseConnectorISpecSetup {
 
       "return error code and message if 500" in {
         givenPegaUpdateCaseRequestFails(500, "500", "Foo Bar")
+        givenAuditConnector()
 
         val request = testRequest
 
@@ -48,6 +49,7 @@ class PegaUpdateCaseConnectorISpec extends PegaUpdateCaseConnectorISpecSetup {
 
       "return error code and message if 403" in {
         givenPegaUpdateCaseRequestFails(403, "403", "Bar Foo")
+        givenAuditConnector()
 
         val request = testRequest
 

--- a/it/uk/gov/hmrc/traderservices/controllers/TraderServicesRouteOneISpec.scala
+++ b/it/uk/gov/hmrc/traderservices/controllers/TraderServicesRouteOneISpec.scala
@@ -15,6 +15,8 @@ import uk.gov.hmrc.traderservices.support.JsonMatchers
 import play.api.libs.json.JsObject
 import java.{util => ju}
 import java.time.ZonedDateTime
+import uk.gov.hmrc.traderservices.services.TraderServicesAuditEvent
+import java.time.ZoneId
 
 class TraderServicesRouteOneISpec
     extends ServerBaseISpec with AuthStubs with CreateCaseStubs with UpdateCaseStubs with JsonMatchers {
@@ -48,6 +50,14 @@ class TraderServicesRouteOneISpec
 
         verifyAuthorisationHasHappened()
         verifyPegaCreateCaseRequestHasHappened()
+        verifyAuditRequestSent(
+          1,
+          TraderServicesAuditEvent.CreateCase,
+          Map(
+            "success"             -> "true",
+            "caseReferenceNumber" -> "PCE201103470D2CC8K0NH3"
+          ) ++ TestData.createRequestDetailsMap
+        )
       }
 
       "return 400 with error code 400 and message if PEGA API call fails with 403" in {
@@ -73,6 +83,12 @@ class TraderServicesRouteOneISpec
 
         verifyAuthorisationHasHappened()
         verifyPegaCreateCaseRequestHasHappened()
+        verifyAuditRequestSent(
+          1,
+          TraderServicesAuditEvent.CreateCase,
+          Map("success" -> "false", "duplicate" -> "false", "errorCode" -> "400")
+            ++ TestData.createRequestDetailsMap
+        )
       }
 
       "return 400 with error code 500 and message if PEGA API call fails with 500" in {
@@ -98,6 +114,12 @@ class TraderServicesRouteOneISpec
 
         verifyAuthorisationHasHappened()
         verifyPegaCreateCaseRequestHasHappened()
+        verifyAuditRequestSent(
+          1,
+          TraderServicesAuditEvent.CreateCase,
+          Map("success" -> "false", "duplicate" -> "false", "errorCode" -> "500", "errorMessage" -> "Foo Bar")
+            ++ TestData.createRequestDetailsMap
+        )
       }
 
       "return 400 with error code 409 and message if PEGA reports duplicated case" in {
@@ -123,6 +145,16 @@ class TraderServicesRouteOneISpec
 
         verifyAuthorisationHasHappened()
         verifyPegaCreateCaseRequestHasHappened()
+        verifyAuditRequestSent(
+          1,
+          TraderServicesAuditEvent.CreateCase,
+          Map(
+            "success"      -> "false",
+            "duplicate"    -> "true",
+            "errorCode"    -> "409",
+            "errorMessage" -> "PCE201103470D2CC8K0NH3"
+          ) ++ TestData.createRequestDetailsMap
+        )
       }
 
       "return 400 with error code 403 if api call returns 403 with empty body" in {
@@ -148,6 +180,16 @@ class TraderServicesRouteOneISpec
 
         verifyAuthorisationHasHappened()
         verifyPegaCreateCaseRequestHasHappened()
+        verifyAuditRequestSent(
+          1,
+          TraderServicesAuditEvent.CreateCase,
+          Map(
+            "success"      -> "false",
+            "duplicate"    -> "false",
+            "errorCode"    -> "403",
+            "errorMessage" -> "Error: empty response"
+          ) ++ TestData.createRequestDetailsMap
+        )
       }
 
       "return 500 if api call returns unexpected content" in {
@@ -166,6 +208,16 @@ class TraderServicesRouteOneISpec
 
         verifyAuthorisationHasHappened()
         verifyPegaCreateCaseRequestHasHappened()
+        verifyAuditRequestSent(
+          1,
+          TraderServicesAuditEvent.CreateCase,
+          Map(
+            "success"      -> "false",
+            "duplicate"    -> "false",
+            "errorCode"    -> "500",
+            "errorMessage" -> "Unexpected response type of status 400, expected application/json but got text/html with body:\n<html>\\r\\n<head><title>400 Bad Request</title></head>\\r\\n<body bgcolor=\\\"white\\\">\\r\\n<center><h1>400 Bad Request</h1></center>\\r\\n<hr><center>nginx</center>\\r\\n</body>\\r\\n</html>\\r\\n\\"
+          )
+        )
       }
     }
 
@@ -201,6 +253,16 @@ class TraderServicesRouteOneISpec
           "PCE201103470D2CC8K0NH3",
           "An example description."
         )
+        verifyAuditRequestSent(
+          1,
+          TraderServicesAuditEvent.UpdateCase,
+          Map(
+            "success"             -> "true",
+            "typeOfAmendment"     -> "WriteResponse",
+            "caseReferenceNumber" -> "PCE201103470D2CC8K0NH3",
+            "responseText"        -> "An example description."
+          )
+        )
       }
 
       "return 201 with CaseID when only files uploaded" in {
@@ -213,15 +275,7 @@ class TraderServicesRouteOneISpec
           caseReferenceNumber = "PCE201103470D2CC8K0NH3",
           typeOfAmendment = TypeOfAmendment.UploadDocuments,
           responseText = None,
-          Seq(
-            UploadedFile(
-              "https://s3.amazonaws/bucket/12817782718728728",
-              ZonedDateTime.now(),
-              "A1A2C3445F65",
-              "my.pdf",
-              "application/pdf"
-            )
-          )
+          TestData.testUpdateCaseRequestUploadedFiles
         )
 
         val result = wsClient
@@ -242,6 +296,15 @@ class TraderServicesRouteOneISpec
           "PCE201103470D2CC8K0NH3",
           "The user has attached the following file(s): my.pdf."
         )
+        verifyAuditRequestSent(
+          1,
+          TraderServicesAuditEvent.UpdateCase,
+          Map(
+            "success"             -> "true",
+            "typeOfAmendment"     -> "UploadDocuments",
+            "caseReferenceNumber" -> "PCE201103470D2CC8K0NH3"
+          ) ++ TestData.updateRequestFileUploadDetailsMap
+        )
       }
 
       "return 201 with CaseID when both response text and files uploaded" in {
@@ -254,15 +317,7 @@ class TraderServicesRouteOneISpec
           caseReferenceNumber = "PCE201103470D2CC8K0NH3",
           typeOfAmendment = TypeOfAmendment.WriteResponseAndUploadDocuments,
           responseText = Some("An example description."),
-          Seq(
-            UploadedFile(
-              "https://s3.amazonaws/bucket/12817782718728728",
-              ZonedDateTime.now(),
-              "A1A2C3445F65",
-              "my.pdf",
-              "application/pdf"
-            )
-          )
+          TestData.testUpdateCaseRequestUploadedFiles
         )
 
         val result = wsClient
@@ -282,6 +337,16 @@ class TraderServicesRouteOneISpec
           "Additional Information",
           "PCE201103470D2CC8K0NH3",
           "An example description."
+        )
+        verifyAuditRequestSent(
+          1,
+          TraderServicesAuditEvent.UpdateCase,
+          Map(
+            "success"             -> "true",
+            "typeOfAmendment"     -> "WriteResponseAndUploadDocuments",
+            "responseText"        -> "An example description.",
+            "caseReferenceNumber" -> "PCE201103470D2CC8K0NH3"
+          ) ++ TestData.updateRequestFileUploadDetailsMap
         )
       }
 
@@ -308,6 +373,11 @@ class TraderServicesRouteOneISpec
 
         verifyAuthorisationHasHappened()
         verifyPegaUpdateCaseRequestHasHappened()
+        verifyAuditRequestSent(
+          1,
+          TraderServicesAuditEvent.UpdateCase,
+          Map("success" -> "false", "errorCode" -> "400") ++ TestData.updateRequestDetailsMap
+        )
       }
 
       "return 400 with error code 500 and message if PEGA API call fails with 500" in {
@@ -333,6 +403,15 @@ class TraderServicesRouteOneISpec
 
         verifyAuthorisationHasHappened()
         verifyPegaUpdateCaseRequestHasHappened()
+        verifyAuditRequestSent(
+          1,
+          TraderServicesAuditEvent.UpdateCase,
+          Map(
+            "success"      -> "false",
+            "errorCode"    -> "500",
+            "errorMessage" -> "Foo Bar"
+          ) ++ TestData.updateRequestDetailsMap
+        )
       }
 
       "return 400 with error code 500 and message if PEGA reports duplicated case" in {
@@ -358,6 +437,15 @@ class TraderServicesRouteOneISpec
 
         verifyAuthorisationHasHappened()
         verifyPegaUpdateCaseRequestHasHappened()
+        verifyAuditRequestSent(
+          1,
+          TraderServicesAuditEvent.UpdateCase,
+          Map(
+            "success"      -> "false",
+            "errorCode"    -> "500",
+            "errorMessage" -> "999: PCE201103470D2CC8K0NH3"
+          ) ++ TestData.updateRequestDetailsMap
+        )
       }
 
       "return 400 with error code 403 if api call returns 403 with empty body" in {
@@ -383,6 +471,15 @@ class TraderServicesRouteOneISpec
 
         verifyAuthorisationHasHappened()
         verifyPegaUpdateCaseRequestHasHappened()
+        verifyAuditRequestSent(
+          1,
+          TraderServicesAuditEvent.UpdateCase,
+          Map(
+            "success"      -> "false",
+            "errorCode"    -> "403",
+            "errorMessage" -> "Error: empty response"
+          ) ++ TestData.updateRequestDetailsMap
+        )
       }
 
       "return 500 if api call returns unexpected content" in {
@@ -401,6 +498,7 @@ class TraderServicesRouteOneISpec
 
         verifyAuthorisationHasHappened()
         verifyPegaUpdateCaseRequestHasHappened()
+        verifyAuditRequestSent(1, TraderServicesAuditEvent.UpdateCase, Map("success" -> "false", "errorCode" -> "500"))
       }
     }
   }
@@ -430,15 +528,70 @@ object TestData {
           contactEmail = "sampelname@gmail.com"
         )
       ),
-      Seq(),
+      Seq(
+        UploadedFile(
+          downloadUrl = "https://s3.amazonaws.com/bucket/test.png",
+          uploadTimestamp = ZonedDateTime.of(2020, 10, 10, 10, 10, 10, 0, ZoneId.of("UTC")),
+          checksum = "7612627146267837821637162783612ve7qwdsagjdhjabHSGUY1T31QWGAhjsahdgy1qtwy",
+          fileName = "test.png",
+          fileMimeType = "image/png"
+        )
+      ),
       "GB123456789012345"
     )
 
+  val createRequestDetailsMap = Map(
+    "eori"                                                -> "GB123456789012345",
+    "questionsAnswers.import.vesselDetails.dateOfArrival" -> "2020-10-29",
+    "questionsAnswers.import.hasALVS"                     -> "false",
+    "questionsAnswers.import.vesselDetails.timeOfArrival" -> "23:45:00",
+    "questionsAnswers.import.requestType"                 -> "New",
+    "questionsAnswers.import.freightType"                 -> "Maritime",
+    "declarationDetails.epu"                              -> "2",
+    "declarationDetails.entryDate"                        -> "2020-09-02",
+    "questionsAnswers.import.routeType"                   -> "Route1",
+    "questionsAnswers.import.vesselDetails.vesselName"    -> "Vessel Name",
+    "declarationDetails.entryNumber"                      -> "A23456A",
+    "questionsAnswers.import.contactInfo.contactNumber"   -> "07123456789",
+    "questionsAnswers.import.contactInfo.contactEmail"    -> "sampelname@gmail.com",
+    "questionsAnswers.import.contactInfo.contactName"     -> "Full Name",
+    "uploadedFiles.0.fileName"                            -> "test.png",
+    "uploadedFiles.0.checksum"                            -> "7612627146267837821637162783612ve7qwdsagjdhjabHSGUY1T31QWGAhjsahdgy1qtwy",
+    "uploadedFiles.0.fileMimeType"                        -> "image/png",
+    "uploadedFiles.0.uploadTimestamp"                     -> "2020-10-10T10:10:10Z[UTC]",
+    "uploadedFiles.0.downloadUrl"                         -> "https://s3.amazonaws.com/bucket/test.png",
+    "numberOfFilesUploaded"                               -> "1"
+  )
+
+  val testUpdateCaseRequestUploadedFiles = Seq(
+    UploadedFile(
+      "https://s3.amazonaws/bucket/12817782718728728",
+      ZonedDateTime.now(),
+      "A1A2C3445F65",
+      "my.pdf",
+      "application/pdf"
+    )
+  )
+
+  val updateRequestFileUploadDetailsMap = Map(
+    "uploadedFiles.0.fileName"     -> "my.pdf",
+    "uploadedFiles.0.checksum"     -> "A1A2C3445F65",
+    "uploadedFiles.0.fileMimeType" -> "application/pdf",
+    "uploadedFiles.0.downloadUrl"  -> "https://s3.amazonaws/bucket/12817782718728728",
+    "numberOfFilesUploaded"        -> "1"
+  )
+
   val testUpdateCaseRequest = TraderServicesUpdateCaseRequest(
     caseReferenceNumber = "PCE201103470D2CC8K0NH3",
-    typeOfAmendment = TypeOfAmendment.WriteResponse,
+    typeOfAmendment = TypeOfAmendment.WriteResponseAndUploadDocuments,
     responseText = Some("An example description."),
-    Seq()
+    testUpdateCaseRequestUploadedFiles
   )
+
+  val updateRequestDetailsMap = Map(
+    "typeOfAmendment"     -> "WriteResponseAndUploadDocuments",
+    "caseReferenceNumber" -> "PCE201103470D2CC8K0NH3",
+    "responseText"        -> "An example description."
+  ) ++ updateRequestFileUploadDetailsMap
 
 }

--- a/it/uk/gov/hmrc/traderservices/stubs/DataStreamStubs.scala
+++ b/it/uk/gov/hmrc/traderservices/stubs/DataStreamStubs.scala
@@ -4,7 +4,7 @@ import org.scalatest.concurrent.Eventually
 import org.scalatest.time.{Millis, Seconds, Span}
 import play.api.libs.json.Json
 import com.github.tomakehurst.wiremock.client.WireMock._
-import uk.gov.hmrc.traderservices.services.TraderServicesEvent.TraderServicesEvent
+import uk.gov.hmrc.traderservices.services.TraderServicesAuditEvent.TraderServicesAuditEvent
 import uk.gov.hmrc.traderservices.support.WireMockSupport
 
 trait DataStreamStubs extends Eventually {
@@ -15,30 +15,30 @@ trait DataStreamStubs extends Eventually {
 
   def verifyAuditRequestSent(
     count: Int,
-    event: TraderServicesEvent,
-    tags: Map[String, String] = Map.empty,
-    detail: Map[String, String] = Map.empty
+    event: TraderServicesAuditEvent,
+    details: Map[String, String] = Map.empty,
+    tags: Map[String, String] = Map.empty
   ): Unit =
     eventually {
       verify(
         count,
         postRequestedFor(urlPathEqualTo(auditUrl))
           .withRequestBody(similarToJson(s"""{
-          |  "auditSource": "trader-services",
+          |  "auditSource": "trader-services-route-one",
           |  "auditType": "$event",
           |  "tags": ${Json.toJson(tags)},
-          |  "detail": ${Json.toJson(detail)}
+          |  "detail": ${Json.toJson(details)}
           |}"""))
       )
     }
 
-  def verifyAuditRequestNotSent(event: TraderServicesEvent): Unit =
+  def verifyAuditRequestNotSent(event: TraderServicesAuditEvent): Unit =
     eventually {
       verify(
         0,
         postRequestedFor(urlPathEqualTo(auditUrl))
           .withRequestBody(similarToJson(s"""{
-          |  "auditSource": "trader-services",
+          |  "auditSource": "trader-services-route-one",
           |  "auditType": "$event"
           |}"""))
       )

--- a/test/uk/gov/hmrc/traderservices/services/AuditServiceSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/services/AuditServiceSpec.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.traderservices.services
+
+import uk.gov.hmrc.traderservices.support.UnitSpec
+import play.api.libs.json._
+
+class AuditServiceSpec extends UnitSpec {
+
+  "AuditService" should {
+    "extract details from json" in {
+      AuditService.detailsFromJson(JsNull) shouldBe Seq.empty
+      AuditService.detailsFromJson(JsTrue) shouldBe Seq("" -> true)
+      AuditService.detailsFromJson(JsFalse) shouldBe Seq("" -> false)
+      AuditService.detailsFromJson(JsString("foo bar")) shouldBe Seq("" -> "foo bar")
+      AuditService.detailsFromJson(JsNumber(10.12d)) shouldBe Seq("" -> 10.12d)
+
+      AuditService.detailsFromJson(Json.obj("foo" -> JsNull)) shouldBe Seq.empty
+      AuditService.detailsFromJson(Json.obj("foo" -> true)) shouldBe Seq("foo" -> true)
+      AuditService.detailsFromJson(Json.obj("bar" -> false)) shouldBe Seq("bar" -> false)
+      AuditService.detailsFromJson(Json.obj("foo" -> "bar")) shouldBe Seq("foo" -> "bar")
+      AuditService.detailsFromJson(Json.obj("foo" -> 0.001d)) shouldBe Seq("foo" -> 0.001d)
+
+      AuditService.detailsFromJson(Json.arr("a")) shouldBe Seq("0" -> "a")
+      AuditService.detailsFromJson(Json.arr("a", 0, true)) shouldBe Seq("0" -> "a", "1" -> 0, "2" -> true)
+      AuditService
+        .detailsFromJson(Json.arr("foo", Json.obj("foo" -> "bar"))) shouldBe Seq("0" -> "foo", "1.foo" -> "bar")
+      AuditService
+        .detailsFromJson(Json.arr(Json.obj("foo" -> "bar"), Json.obj("foo" -> "baz"))) shouldBe Seq(
+        "0.foo" -> "bar",
+        "1.foo" -> "baz"
+      )
+
+      AuditService.detailsFromJson(Json.obj("foo" -> Json.obj("bar" -> 1))) shouldBe Seq("foo.bar" -> 1)
+
+      AuditService.detailsFromJson(Json.obj("foo" -> Json.obj("bar" -> 1, "baz" -> "foz"))) shouldBe Seq(
+        "foo.bar" -> 1,
+        "foo.baz" -> "foz"
+      )
+
+      AuditService.detailsFromJson(
+        Json.obj(
+          "foo" -> Json.obj("bar" -> 1, "baz" -> "foz"),
+          "faz" -> Json.obj("bar" -> Json.obj("bar" -> true), "foz" -> "baz")
+        )
+      ) shouldBe Seq(
+        "foo.bar"     -> 1,
+        "foo.baz"     -> "foz",
+        "faz.bar.bar" -> true,
+        "faz.foz"     -> "baz"
+      )
+
+      AuditService.detailsFromJson(
+        Json.obj(
+          "foo" -> Json.arr(Json.obj("fos" -> 1), Json.obj("fos" -> "baz")),
+          "faz" -> Json.arr(Json.obj("fas" -> "bar"), Json.obj("fas" -> false))
+        )
+      ) shouldBe Seq(
+        "foo.0.fos" -> 1,
+        "foo.1.fos" -> "baz",
+        "faz.0.fas" -> "bar",
+        "faz.1.fas" -> false
+      )
+    }
+  }
+
+}


### PR DESCRIPTION
This PR adds two explicit audit events: CreateCase and UpdateCase.

The evidence of them being sent can be found locally in the AES logs using `sm --logs AGENTS_EXTERNAL_STUBS`, or on the DEVELOPMENT environment using Kibana.