### PR TITLE
[DOR-437][AO] support new optional field `explanation` in the CreateCase API

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,19 +37,20 @@ Example request payload
         },
         "questionsAnswers" : {
             "export" : {
-            "requestType" : "New",
-            "routeType" : "Route2",
-            "freightType" : "Air",
-            "vesselDetails" : {
-                "vesselName" : "Foo Bar",
-                "dateOfArrival" : "2020-10-19",
-                "timeOfArrival" : "10:09:00"
-            },
-            "contactInfo" : {
-                "contactName" : "Bob",
-                "contactEmail" : "name@somewhere.com",
-                "contactNumber" : "01234567891"
-            }
+                "requestType" : "New",
+                "routeType" : "Route2",
+                "freightType" : "Air",
+                "vesselDetails" : {
+                    "vesselName" : "Foo Bar",
+                    "dateOfArrival" : "2020-10-19",
+                    "timeOfArrival" : "10:09:00"
+                },
+                "contactInfo" : {
+                    "contactName" : "Bob",
+                    "contactEmail" : "name@somewhere.com",
+                    "contactNumber" : "01234567891"
+                },
+                "explanation": "lorem ipsum ..."
             }
         },
         "uploadedFiles" : [ {

--- a/app/uk/gov/hmrc/traderservices/connectors/FileTransferConnector.scala
+++ b/app/uk/gov/hmrc/traderservices/connectors/FileTransferConnector.scala
@@ -58,11 +58,12 @@ class FileTransferConnector @Inject() (
         fileTransferRequest.checksum,
         fileTransferRequest.fileName,
         fileTransferRequest.fileMimeType,
-        fileTransferRequest.fileSize,
+        fileTransferRequest.fileSize.getOrElse(0),
         isSuccess(response),
         response.status,
         LocalDateTime.now(),
         hc.requestId.map(_.value).getOrElse(""),
+        0,
         None
       )
     )

--- a/app/uk/gov/hmrc/traderservices/connectors/PegaCreateCaseRequest.scala
+++ b/app/uk/gov/hmrc/traderservices/connectors/PegaCreateCaseRequest.scala
@@ -91,7 +91,8 @@ object PegaCreateCaseRequest {
               hasALVS,
               freightType,
               vesselDetails,
-              contactInfo
+              contactInfo,
+              explanation
             ) =>
           Content(
             EntryType = "Import",
@@ -118,7 +119,8 @@ object PegaCreateCaseRequest {
               priorityGoods,
               freightType,
               vesselDetails,
-              contactInfo
+              contactInfo,
+              explanation
             ) =>
           Content(
             EntryType = "Export",

--- a/app/uk/gov/hmrc/traderservices/controllers/CreateCaseLog.scala
+++ b/app/uk/gov/hmrc/traderservices/controllers/CreateCaseLog.scala
@@ -85,7 +85,7 @@ object CreateCaseLog {
         fileTransferSuccesses = response.result.map(_.fileTransferResults.count(_.success)),
         fileTransferFailures = response.result.map(_.fileTransferResults.count(f => !f.success)),
         fileCorrelationIds = response.result.map(_.fileTransferResults.map(_.correlationId)).getOrElse(Seq.empty),
-        filesSize = response.result.map(_.fileTransferResults.map(_.fileSize.getOrElse(0)).sum)
+        filesSize = response.result.map(_.fileTransferResults.map(_.fileSize).sum)
       )
     Logger(getClass()).info(s"json${Json.stringify(Json.toJson(log))}")
   }

--- a/app/uk/gov/hmrc/traderservices/controllers/UpdateCaseLog.scala
+++ b/app/uk/gov/hmrc/traderservices/controllers/UpdateCaseLog.scala
@@ -50,7 +50,7 @@ object UpdateCaseLog {
         fileTransferSuccesses = response.result.map(_.fileTransferResults.count(_.success)),
         fileTransferFailures = response.result.map(_.fileTransferResults.count(f => !f.success)),
         fileCorrelationIds = response.result.map(_.fileTransferResults.map(_.correlationId)).getOrElse(Seq.empty),
-        filesSize = response.result.map(_.fileTransferResults.map(_.fileSize.getOrElse(0)).sum)
+        filesSize = response.result.map(_.fileTransferResults.map(_.fileSize).sum)
       )
     Logger(getClass()).info(s"json${Json.stringify(Json.toJson(log))}")
 

--- a/app/uk/gov/hmrc/traderservices/models/ExportQuestions.scala
+++ b/app/uk/gov/hmrc/traderservices/models/ExportQuestions.scala
@@ -24,7 +24,8 @@ case class ExportQuestions(
   priorityGoods: Option[ExportPriorityGoods] = None,
   freightType: ExportFreightType,
   vesselDetails: Option[VesselDetails] = None,
-  contactInfo: ContactInfo
+  contactInfo: ContactInfo,
+  explanation: Option[String] = None
 ) extends QuestionsAnswers
 
 object ExportQuestions {

--- a/app/uk/gov/hmrc/traderservices/models/FileTransferAudit.scala
+++ b/app/uk/gov/hmrc/traderservices/models/FileTransferAudit.scala
@@ -24,7 +24,7 @@ import java.time.LocalDateTime
 case class FileTransferAudit(
   upscanReference: String,
   downloadUrl: String,
-  uploadTimestamp: ZonedDateTime,
+  uploadTimestamp: Option[ZonedDateTime] = None,
   checksum: String,
   fileName: String,
   fileMimeType: String,

--- a/app/uk/gov/hmrc/traderservices/models/FileTransferResult.scala
+++ b/app/uk/gov/hmrc/traderservices/models/FileTransferResult.scala
@@ -25,11 +25,12 @@ final case class FileTransferResult(
   checksum: String,
   fileName: String,
   fileMimeType: String,
-  fileSize: Option[Int],
+  fileSize: Int,
   success: Boolean,
   httpStatus: Int,
   transferredAt: LocalDateTime,
   correlationId: String,
+  durationMillis: Int,
   error: Option[String] = None
 )
 

--- a/app/uk/gov/hmrc/traderservices/models/ImportQuestions.scala
+++ b/app/uk/gov/hmrc/traderservices/models/ImportQuestions.scala
@@ -25,7 +25,8 @@ case class ImportQuestions(
   hasALVS: Boolean,
   freightType: ImportFreightType,
   vesselDetails: Option[VesselDetails] = None,
-  contactInfo: ContactInfo
+  contactInfo: ContactInfo,
+  explanation: Option[String] = None
 ) extends QuestionsAnswers
 
 object ImportQuestions {

--- a/app/uk/gov/hmrc/traderservices/models/MultiFileTransferResult.scala
+++ b/app/uk/gov/hmrc/traderservices/models/MultiFileTransferResult.scala
@@ -18,12 +18,15 @@ package uk.gov.hmrc.traderservices.models
 
 import play.api.libs.json.Format
 import play.api.libs.json.Json
+import play.api.libs.json.JsObject
 
 final case class MultiFileTransferResult(
   conversationId: String,
   caseReferenceNumber: String,
   applicationName: String,
-  results: Seq[FileTransferResult]
+  results: Seq[FileTransferResult],
+  totalDurationMillis: Int,
+  metadata: Option[JsObject] = None
 )
 
 object MultiFileTransferResult {

--- a/app/uk/gov/hmrc/traderservices/models/QuestionsAnswers.scala
+++ b/app/uk/gov/hmrc/traderservices/models/QuestionsAnswers.scala
@@ -23,7 +23,9 @@ import play.api.libs.json.JsValue
 import play.api.libs.json.JsObject
 import play.api.libs.json.JsError
 
-trait QuestionsAnswers
+trait QuestionsAnswers {
+  def explanation: Option[String]
+}
 
 object QuestionsAnswers {
 

--- a/app/uk/gov/hmrc/traderservices/utilities/MessageUtils.scala
+++ b/app/uk/gov/hmrc/traderservices/utilities/MessageUtils.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.traderservices.stubs
+
+import java.io.InputStream
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.util.Base64
+import java.io.ByteArrayInputStream
+
+object MessageUtils {
+
+  private val chunkSize: Int = 2400
+
+  final def encodeBase64AndCalculateSHA256(string: String): (String, String) =
+    encodeBase64AndCalculateSHA256(string.getBytes(StandardCharsets.UTF_8))
+
+  final def encodeBase64AndCalculateSHA256(bytes: Array[Byte]): (String, String) = {
+    val (_, base64Message, sha256Checksum, _) =
+      read(new ByteArrayInputStream(bytes))
+    (base64Message, sha256Checksum)
+  }
+
+  /**
+    * Reads byte stream, wraps as Base64 and calculates SHA-256 checksum.
+    *
+    * @param io input stream
+    * @return (source bytes, base64 encoded message, checkum, length)
+    */
+  final def read(io: InputStream): (Array[Byte], String, String, Int) = {
+    val digest = MessageDigest.getInstance("SHA-256")
+    val chunk = Array.ofDim[Byte](chunkSize)
+    val encoder = Base64.getEncoder()
+    var hasNext = true
+    val rawBuffer = ByteBuffer.allocate(10 * 1024 * 1024)
+    val encodedBuffer = ByteBuffer.allocate(14 * 1024 * 1024)
+    var fileSize = 0
+    while (hasNext) {
+      for (i <- 0 until chunkSize) chunk.update(i, 0)
+      val readLength = io.read(chunk)
+      hasNext = readLength != -1
+      if (readLength >= 0) {
+        fileSize = fileSize + readLength
+        val chunkBytes =
+          if (readLength == chunk.length) chunk
+          else chunk.take(readLength)
+        digest.update(chunkBytes)
+        val encoded = encoder.encode(chunkBytes)
+        encodedBuffer.put(encoded)
+        rawBuffer.put(chunkBytes)
+      }
+    }
+    val bytes = Array.ofDim[Byte](rawBuffer.position())
+    rawBuffer.clear()
+    rawBuffer.get(bytes)
+    val encoded = Array.ofDim[Byte](encodedBuffer.position())
+    encodedBuffer.clear()
+    encodedBuffer.get(encoded)
+    io.close()
+    val checksum = digest.digest()
+    val contentBase64 = new String(encoded, StandardCharsets.UTF_8)
+    (bytes, contentBase64, convertBytesToHex(checksum), bytes.length)
+  }
+
+  final def convertBytesToHex(bytes: Array[Byte]): String = {
+    val sb = new StringBuilder
+    for (b <- bytes)
+      sb.append(String.format("%02x", Byte.box(b)))
+    sb.toString
+  }
+
+}

--- a/it/uk/gov/hmrc/traderservices/controllers/CreateUpdateCaseControllerAsyncISpec.scala
+++ b/it/uk/gov/hmrc/traderservices/controllers/CreateUpdateCaseControllerAsyncISpec.scala
@@ -47,13 +47,20 @@ class CreateUpdateCaseControllerAsyncISpec
         val correlationId = ju.UUID.randomUUID().toString()
         givenAuthorised()
         givenPegaCreateImportCaseRequestSucceeds(200)
+
         val createCaseRequest =
           TestData.testCreateImportCaseRequest(wireMockBaseUrlAsString)
+
+        val files = FileTransferData.fromUploadedFilesAndExplanation(
+          createCaseRequest.uploadedFiles,
+          createCaseRequest.questionsAnswers.explanation
+        )
+
         givenMultiFileTransferSucceeds(
           "PCE201103470D2CC8K0NH3",
           "Route1",
           correlationId,
-          createCaseRequest.uploadedFiles.map(FileTransferData.fromUploadedFile)
+          files
         )
 
         val result = wsClient
@@ -82,7 +89,7 @@ class CreateUpdateCaseControllerAsyncISpec
             Json.obj(
               "success"             -> true,
               "caseReferenceNumber" -> "PCE201103470D2CC8K0NH3"
-            ) ++ TestData.createImportRequestDetails(wireMockBaseUrlAsString, transferSuccess = true)
+            ) ++ TestData.createImportRequestDetails(wireMockBaseUrlAsString, transferSuccess = true, files = files)
           )
         }
       }
@@ -91,14 +98,22 @@ class CreateUpdateCaseControllerAsyncISpec
         val correlationId = ju.UUID.randomUUID().toString()
         givenAuthorised()
         givenPegaCreateExportCaseRequestSucceeds()
+
         val createCaseRequest =
           TestData.testCreateExportCaseRequest(wireMockBaseUrlAsString)
+
+        val files = FileTransferData.fromUploadedFilesAndExplanation(
+          createCaseRequest.uploadedFiles,
+          createCaseRequest.questionsAnswers.explanation
+        )
+
         givenMultiFileTransferSucceeds(
           "PCE201103470D2CC8K0NH3",
           "Route1",
           correlationId,
-          createCaseRequest.uploadedFiles.map(FileTransferData.fromUploadedFile)
+          files
         )
+
         val result = wsClient
           .url(s"$baseUrl/create-case")
           .withHttpHeaders("X-Correlation-ID" -> correlationId)
@@ -125,7 +140,7 @@ class CreateUpdateCaseControllerAsyncISpec
             Json.obj(
               "success"             -> true,
               "caseReferenceNumber" -> "PCE201103470D2CC8K0NH3"
-            ) ++ TestData.createExportRequestDetails(wireMockBaseUrlAsString, transferSuccess = true)
+            ) ++ TestData.createExportRequestDetails(wireMockBaseUrlAsString, transferSuccess = true, files = files)
           )
         }
       }
@@ -250,7 +265,7 @@ class CreateUpdateCaseControllerAsyncISpec
           1,
           TraderServicesAuditEvent.CreateCase,
           Json.obj("success" -> false, "duplicate" -> false, "errorCode" -> "400")
-            ++ TestData.createImportRequestDetails(wireMockBaseUrlAsString, transferSuccess = false)
+            ++ TestData.createImportRequestDetails(wireMockBaseUrlAsString, transferSuccess = false, files = Seq.empty)
         )
       }
 
@@ -279,7 +294,7 @@ class CreateUpdateCaseControllerAsyncISpec
           1,
           TraderServicesAuditEvent.CreateCase,
           Json.obj("success" -> false, "duplicate" -> false, "errorCode" -> "500", "errorMessage" -> "Foo Bar")
-            ++ TestData.createImportRequestDetails(wireMockBaseUrlAsString, transferSuccess = false)
+            ++ TestData.createImportRequestDetails(wireMockBaseUrlAsString, transferSuccess = false, files = Seq.empty)
         )
       }
 
@@ -315,7 +330,7 @@ class CreateUpdateCaseControllerAsyncISpec
             "duplicate"    -> true,
             "errorCode"    -> "409",
             "errorMessage" -> "PCE201103470D2CC8K0NH3"
-          ) ++ TestData.createImportRequestDetails(wireMockBaseUrlAsString, transferSuccess = false)
+          ) ++ TestData.createImportRequestDetails(wireMockBaseUrlAsString, transferSuccess = false, files = Seq.empty)
         )
       }
 
@@ -351,7 +366,7 @@ class CreateUpdateCaseControllerAsyncISpec
             "duplicate"    -> true,
             "errorCode"    -> "409",
             "errorMessage" -> "PCE201103470D2CC8K0NH3"
-          ) ++ TestData.createExportRequestDetails(wireMockBaseUrlAsString, transferSuccess = false)
+          ) ++ TestData.createExportRequestDetails(wireMockBaseUrlAsString, transferSuccess = false, files = Seq.empty)
         )
       }
 
@@ -387,7 +402,7 @@ class CreateUpdateCaseControllerAsyncISpec
             "duplicate"    -> false,
             "errorCode"    -> "403",
             "errorMessage" -> "Error: empty response"
-          ) ++ TestData.createImportRequestDetails(wireMockBaseUrlAsString, transferSuccess = false)
+          ) ++ TestData.createImportRequestDetails(wireMockBaseUrlAsString, transferSuccess = false, files = Seq.empty)
         )
       }
 

--- a/it/uk/gov/hmrc/traderservices/stubs/FileTransferStubs.scala
+++ b/it/uk/gov/hmrc/traderservices/stubs/FileTransferStubs.scala
@@ -84,16 +84,19 @@ trait FileTransferStubs {
                          |   "caseReferenceNumber":"$caseReferenceNumber",
                          |   "applicationName":"$applicationName",
                          |   "conversationId":"$conversationId",
+                         |   "totalDurationMillis": 2222,
                          |   "results": [ ${files
               .map(file => s"""{
                          |          "upscanReference":"${file.upscanReference}",
-                         |          "fileName":"${file.downloadUrl}",
+                         |          "fileName":"${file.fileName}",
                          |          "fileMimeType":"${file.fileMimeType}"
                          |          ${file.fileSize.map(s => s""", "fileSize":$s""").getOrElse("")},
                          |          "checksum":"${file.checksum}",
+                         |          "fileSize": 1024,
                          |          "success": true,
                          |          "httpStatus": 202,
                          |          "transferredAt": "2021-07-17T12:18:09",
+                         |          "durationMillis": 1234,
                          |          "correlationId": "${UUID.randomUUID}"
                          |      }""".stripMargin)
               .mkString(",")}

--- a/test/uk/gov/hmrc/traderservices/utilities/CommonUtilsSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/utilities/CommonUtilsSpec.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.traderservices.utilities
 import uk.gov.hmrc.traderservices.support.UnitSpec
 import uk.gov.hmrc.traderservices.utilities.CommonUtils.LocalDateTimeUtils
 class CommonUtilsSpec extends UnitSpec {
-  "LocalDateTimeUtils" should {
+  "CommonUtils" should {
     "parse date string correctly" in {
       "2020-11-03T15:29:28.601Z".toLocaDateTime.toString shouldBe "2020-11-03T15:29:28.601"
       "2020-01-12T00:00:00.000Z".toLocaDateTime.toString shouldBe "2020-01-12T00:00"

--- a/test/uk/gov/hmrc/traderservices/utilities/MessageUtilsSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/utilities/MessageUtilsSpec.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.traderservices.utilities
+
+import uk.gov.hmrc.traderservices.support.UnitSpec
+import uk.gov.hmrc.traderservices.stubs.MessageUtils
+
+class MessageUtilsSpec extends UnitSpec {
+  "MessageUtils" should {
+    "encode string as Base64 and calculate SHA-256 checksum" in {
+      MessageUtils.encodeBase64AndCalculateSHA256("") shouldBe (
+        (
+          "",
+          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        )
+      )
+      MessageUtils.encodeBase64AndCalculateSHA256("a") shouldBe (
+        (
+          "YQ==",
+          "ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb"
+        )
+      )
+      MessageUtils.encodeBase64AndCalculateSHA256("Hello!") shouldBe (
+        (
+          "SGVsbG8h",
+          "334d016f755cd6dc58c53a86e183882f8ec14f52fb05345887c8a5edd42c87b7"
+        )
+      )
+      MessageUtils.encodeBase64AndCalculateSHA256(
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin tempus tempor est in dapibus. Maecenas dignissim elit in tempus vehicula. Nullam nunc eros, laoreet eu augue a, elementum mattis leo. Vestibulum accumsan semper felis, ac commodo velit consequat nec. Nulla facilisi. Sed ac dui eu velit porta pharetra sollicitudin id nunc. Aenean ipsum ipsum, aliquam eget nisi id, eleifend dapibus quam. Vivamus in imperdiet diam. Vestibulum nec interdum nisl. Praesent sed massa nec est pellentesque accumsan eu in mi. Vivamus pellentesque purus eleifend eros ornare, non cursus dolor bibendum. Donec feugiat diam sit amet rhoncus condimentum. Morbi sagittis vitae nulla."
+      ) shouldBe (
+        (
+          "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gUHJvaW4gdGVtcHVzIHRlbXBvciBlc3QgaW4gZGFwaWJ1cy4gTWFlY2VuYXMgZGlnbmlzc2ltIGVsaXQgaW4gdGVtcHVzIHZlaGljdWxhLiBOdWxsYW0gbnVuYyBlcm9zLCBsYW9yZWV0IGV1IGF1Z3VlIGEsIGVsZW1lbnR1bSBtYXR0aXMgbGVvLiBWZXN0aWJ1bHVtIGFjY3Vtc2FuIHNlbXBlciBmZWxpcywgYWMgY29tbW9kbyB2ZWxpdCBjb25zZXF1YXQgbmVjLiBOdWxsYSBmYWNpbGlzaS4gU2VkIGFjIGR1aSBldSB2ZWxpdCBwb3J0YSBwaGFyZXRyYSBzb2xsaWNpdHVkaW4gaWQgbnVuYy4gQWVuZWFuIGlwc3VtIGlwc3VtLCBhbGlxdWFtIGVnZXQgbmlzaSBpZCwgZWxlaWZlbmQgZGFwaWJ1cyBxdWFtLiBWaXZhbXVzIGluIGltcGVyZGlldCBkaWFtLiBWZXN0aWJ1bHVtIG5lYyBpbnRlcmR1bSBuaXNsLiBQcmFlc2VudCBzZWQgbWFzc2EgbmVjIGVzdCBwZWxsZW50ZXNxdWUgYWNjdW1zYW4gZXUgaW4gbWkuIFZpdmFtdXMgcGVsbGVudGVzcXVlIHB1cnVzIGVsZWlmZW5kIGVyb3Mgb3JuYXJlLCBub24gY3Vyc3VzIGRvbG9yIGJpYmVuZHVtLiBEb25lYyBmZXVnaWF0IGRpYW0gc2l0IGFtZXQgcmhvbmN1cyBjb25kaW1lbnR1bS4gTW9yYmkgc2FnaXR0aXMgdml0YWUgbnVsbGEu",
+          "ab8615431fec545eba5e66c0c6fa460b531dff9b5a18bde3b28dca7c4b5dffaa"
+        )
+      )
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a new optional input field `explanation` of type String and, if provided, attaches its content to the case in the form of a separate text document.