### PR TITLE
[DOR-460][AO] do not validate file name length

### DIFF
--- a/app/uk/gov/hmrc/traderservices/models/TraderServicesCreateCaseRequest.scala
+++ b/app/uk/gov/hmrc/traderservices/models/TraderServicesCreateCaseRequest.scala
@@ -91,10 +91,6 @@ object TraderServicesCreateCaseRequest {
       ),
       check(_.fileMimeType.nonEmpty, "fileMimeType must be not empty"),
       check(_.fileName.nonEmpty, "fileName must be not empty"),
-      check(
-        _.fileName.length < 94,
-        "fileName must be less than 94 characters"
-      ),
       check(_.fileSize.forall(_ > 0), "fileSize must be greater than zero"),
       check(_.fileSize.forall(_ <= 6 * 1024 * 1024), "fileSize must be lower or equal to 6MB")
     )

--- a/test/uk/gov/hmrc/traderservices/models/TraderServicesCreateCaseRequestSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/models/TraderServicesCreateCaseRequestSpec.scala
@@ -125,11 +125,11 @@ class TraderServicesCreateCaseRequestSpec extends UnitSpec {
           "https://aaa.aa/aaa.aa",
           ZonedDateTime.now,
           "a" * 64,
-          "a" * 94,
+          "a" * 256,
           "aaaa/aaaa",
           Some(1)
         )
-      ).isValid shouldBe false
+      ).isValid shouldBe true
       uploadedFileValidator(
         UploadedFile("", "", ZonedDateTime.now, "", "", "", None)
       ).isValid shouldBe false


### PR DESCRIPTION
This PR removes file name length validation because file-transmission-synchronous will now take care of trimming the name if needed, see https://github.com/hmrc/file-transmission-synchronous/pull/18