### PR TITLE
[DOR-463][AO] log and audit total duration of the file transfers

### DIFF
--- a/app/uk/gov/hmrc/traderservices/controllers/CreateCaseLog.scala
+++ b/app/uk/gov/hmrc/traderservices/controllers/CreateCaseLog.scala
@@ -31,7 +31,9 @@ case class CreateCaseLog(
   fileTransferSuccesses: Option[Int],
   fileTransferFailures: Option[Int],
   fileCorrelationIds: Seq[String],
-  filesSize: Option[Int]
+  fileTransferDurations: Seq[Int],
+  filesSize: Option[Int],
+  totalFileTransferDurationMillis: Option[Int]
 )
 
 object CreateCaseLog {
@@ -85,7 +87,9 @@ object CreateCaseLog {
         fileTransferSuccesses = response.result.map(_.fileTransferResults.count(_.success)),
         fileTransferFailures = response.result.map(_.fileTransferResults.count(f => !f.success)),
         fileCorrelationIds = response.result.map(_.fileTransferResults.map(_.correlationId)).getOrElse(Seq.empty),
-        filesSize = response.result.map(_.fileTransferResults.map(_.fileSize).sum)
+        fileTransferDurations = response.result.map(_.fileTransferResults.map(_.durationMillis)).getOrElse(Seq.empty),
+        filesSize = response.result.map(_.fileTransferResults.map(_.fileSize).sum),
+        totalFileTransferDurationMillis = response.result.flatMap(_.totalFileTransferDurationMillis)
       )
     Logger(getClass()).info(s"json${Json.stringify(Json.toJson(log))}")
   }

--- a/app/uk/gov/hmrc/traderservices/controllers/UpdateCaseLog.scala
+++ b/app/uk/gov/hmrc/traderservices/controllers/UpdateCaseLog.scala
@@ -31,7 +31,9 @@ case class UpdateCaseLog(
   fileTransferSuccesses: Option[Int],
   fileTransferFailures: Option[Int],
   fileCorrelationIds: Seq[String],
-  filesSize: Option[Int]
+  fileTransferDurations: Seq[Int],
+  filesSize: Option[Int],
+  totalFileTransferDurationMillis: Option[Int]
 )
 
 object UpdateCaseLog {
@@ -50,7 +52,9 @@ object UpdateCaseLog {
         fileTransferSuccesses = response.result.map(_.fileTransferResults.count(_.success)),
         fileTransferFailures = response.result.map(_.fileTransferResults.count(f => !f.success)),
         fileCorrelationIds = response.result.map(_.fileTransferResults.map(_.correlationId)).getOrElse(Seq.empty),
-        filesSize = response.result.map(_.fileTransferResults.map(_.fileSize).sum)
+        fileTransferDurations = response.result.map(_.fileTransferResults.map(_.durationMillis)).getOrElse(Seq.empty),
+        filesSize = response.result.map(_.fileTransferResults.map(_.fileSize).sum),
+        totalFileTransferDurationMillis = response.result.flatMap(_.totalFileTransferDurationMillis)
       )
     Logger(getClass()).info(s"json${Json.stringify(Json.toJson(log))}")
 

--- a/app/uk/gov/hmrc/traderservices/models/TraderServicesCaseResponse.scala
+++ b/app/uk/gov/hmrc/traderservices/models/TraderServicesCaseResponse.scala
@@ -24,7 +24,8 @@ import java.time.LocalDateTime
 case class TraderServicesResult(
   caseId: String,
   generatedAt: LocalDateTime,
-  fileTransferResults: Seq[FileTransferResult]
+  fileTransferResults: Seq[FileTransferResult],
+  totalFileTransferDurationMillis: Option[Int]
 )
 
 object TraderServicesResult {

--- a/app/uk/gov/hmrc/traderservices/services/AuditService.scala
+++ b/app/uk/gov/hmrc/traderservices/services/AuditService.scala
@@ -153,7 +153,8 @@ object AuditService {
     numberOfFilesUploaded: Int,
     uploadedFiles: Seq[FileTransferAudit],
     correlationId: String,
-    reason: Option[String]
+    reason: Option[String],
+    totalFileTransferDurationMillis: Option[Int]
   )
 
   object CreateCaseAuditEventDetails {
@@ -190,7 +191,8 @@ object AuditService {
                   q.reason
                 ),
                 correlationId = createResponse.correlationId,
-                reason = q.reason
+                reason = q.reason,
+                totalFileTransferDurationMillis = createResponse.result.flatMap(_.totalFileTransferDurationMillis)
               )
 
             case q: ExportQuestions =>
@@ -218,7 +220,8 @@ object AuditService {
                   q.reason
                 ),
                 correlationId = createResponse.correlationId,
-                reason = q.reason
+                reason = q.reason,
+                totalFileTransferDurationMillis = createResponse.result.flatMap(_.totalFileTransferDurationMillis)
               )
           }
         )
@@ -241,7 +244,8 @@ object AuditService {
     responseText: Option[String] = None,
     numberOfFilesUploaded: Int,
     uploadedFiles: Seq[FileTransferAudit],
-    correlationId: String
+    correlationId: String,
+    totalFileTransferDurationMillis: Option[Int]
   )
 
   object UpdateCaseAuditEventDetails {
@@ -264,7 +268,8 @@ object AuditService {
               updateResponse.result.map(_.fileTransferResults),
               None
             ),
-            correlationId = updateResponse.correlationId
+            correlationId = updateResponse.correlationId,
+            totalFileTransferDurationMillis = updateResponse.result.flatMap(_.totalFileTransferDurationMillis)
           )
         )
         .as[JsObject]


### PR DESCRIPTION
This PR amends Kibana log and audit events with the information about the total duration of the files transfer, based on the `totalDurationMillis` attribute returned in the {{/transfer-multiple-files}} response body.